### PR TITLE
Lfsr procedural

### DIFF
--- a/info.yaml
+++ b/info.yaml
@@ -18,7 +18,7 @@ project:
   # Don't forget to also update `PROJECT_SOURCES` in test/Makefile.
   source_files:
     - "project.v"
-    - "LFSR_2.v"
+    # - "LFSR_2.v"
     - "LFSR.v"
 
 # The pinout of your project. Leave unused pins blank. DO NOT delete or add any pins.

--- a/info.yaml
+++ b/info.yaml
@@ -18,6 +18,7 @@ project:
   # Don't forget to also update `PROJECT_SOURCES` in test/Makefile.
   source_files:
     - "project.v"
+    - "LFSR.v"
 
 # The pinout of your project. Leave unused pins blank. DO NOT delete or add any pins.
 # This section is for the datasheet/website. Use descriptive names (e.g., RX, TX, MOSI, SCL, SEG_A, etc.).

--- a/info.yaml
+++ b/info.yaml
@@ -1,17 +1,17 @@
 # Tiny Tapeout project information
 project:
-  title:        "tinytapeout"      # Project title
-  author:       "Noah"      # Your name
-  discord:      ""      # Your discord username, for communication and automatically assigning you a Tapeout role (optional)
-  description:  "random_number_generators"      # One line description of what your project does
-  language:     "Verilog" # other examples include SystemVerilog, Amaranth, VHDL, etc
-  clock_hz:     0       # Clock frequency in Hz (or 0 if not applicable)
+  title: "tinytapeout" # Project title
+  author: "Noah Hu and Michelle Chen" # Your name
+  discord: "" # Your discord username, for communication and automatically assigning you a Tapeout role (optional)
+  description: "Simon Says Game" # One line description of what your project does
+  language: "Verilog" # other examples include SystemVerilog, Amaranth, VHDL, etc
+  clock_hz: 0 # Clock frequency in Hz (or 0 if not applicable)
 
   # How many tiles your design occupies? A single tile is about 167x108 uM.
-  tiles: "1x1"          # Valid values: 1x1, 1x2, 2x2, 3x2, 4x2, 6x2 or 8x2
+  tiles: "1x1" # Valid values: 1x1, 1x2, 2x2, 3x2, 4x2, 6x2 or 8x2
 
   # Your top module name must start with "tt_um_". Make it unique by including your github username:
-  top_module:  "tt_um_example"
+  top_module: "tt_um_simonsays"
 
   # List your project's source files here.
   # Source files must be in ./src and you must list each source file separately, one per line.

--- a/info.yaml
+++ b/info.yaml
@@ -18,7 +18,7 @@ project:
   # Don't forget to also update `PROJECT_SOURCES` in test/Makefile.
   source_files:
     - "project.v"
-    - "LFSR.v"
+    - "LFSR_2.v"
 
 # The pinout of your project. Leave unused pins blank. DO NOT delete or add any pins.
 # This section is for the datasheet/website. Use descriptive names (e.g., RX, TX, MOSI, SCL, SEG_A, etc.).

--- a/info.yaml
+++ b/info.yaml
@@ -19,6 +19,7 @@ project:
   source_files:
     - "project.v"
     - "LFSR_2.v"
+    - "LFSR.v"
 
 # The pinout of your project. Leave unused pins blank. DO NOT delete or add any pins.
 # This section is for the datasheet/website. Use descriptive names (e.g., RX, TX, MOSI, SCL, SEG_A, etc.).

--- a/src/LFSR.v
+++ b/src/LFSR.v
@@ -1,0 +1,47 @@
+module LFSR (
+    input [6:0] LFSR_SEED, // Load value
+    input clk,
+    input rst,
+    input enable,
+    output [6:0] LFSR_OUT,
+    output complete_LFSR
+);
+
+    reg [6:0] LFSR_out_next = 7'b0; // Next value to be assigned
+    reg complete_LFSR_reg = 1'b0; // Register to hold completion status
+    reg [3:0] count = 4'b0; // Counter to track the number of cycles
+
+    always @(posedge clk or posedge rst) begin
+        if (rst) begin
+            //LFSR_out_next <= LFSR_SEED; // Load the seed value on reset
+            complete_LFSR_reg <= 1'b0; // Reset completion status
+            count <= 4'b0; // Reset the cycle counter
+        end else if (!enable) begin
+            // If not enabled, hold the current value
+            LFSR_out_next <= 7'bzzzzzzz; // Maintain current state
+            complete_LFSR_reg <= 0; // Maintain completion status
+            count <= 0; // Maintain cycle count
+        end else if (enable && !complete_LFSR_reg) begin
+            // If all zeros, reload the seed
+            if (LFSR_out_next == 7'b0000000) begin
+                LFSR_out_next <= LFSR_SEED;
+                complete_LFSR_reg <= 1'b0;
+                count <= 4'b0;
+            end else begin
+                // 7-bit LFSR with taps at bits 7 and 6 (primitive polynomial x^7 + x^6 + 1)
+                LFSR_out_next <= {LFSR_out_next[5:0], LFSR_out_next[6] ^ LFSR_out_next[5]};
+                if (count < 7 && !complete_LFSR_reg) begin
+                    count <= count + 1;
+                    complete_LFSR_reg <= 1'b0;
+                end else if (count == 7) begin
+                    complete_LFSR_reg <= 1'b1; // Set complete after 8 shifts
+                end
+            end
+        end
+        // else: hold value (do nothing)
+    end
+
+    assign LFSR_OUT = LFSR_out_next;
+    assign complete_LFSR = complete_LFSR_reg;
+
+endmodule

--- a/src/LFSR.v
+++ b/src/LFSR.v
@@ -7,9 +7,9 @@ module LFSR (
     output complete_LFSR
 );
 
-    reg [6:0] LFSR_out_next = 7'b0; // Next value to be assigned
-    reg complete_LFSR_reg = 1'b0; // Register to hold completion status
-    reg [3:0] count = 4'b0; // Counter to track the number of cycles
+    // reg [6:0] LFSR_out_next = 7'b0; // Next value to be assigned
+    // reg complete_LFSR_reg = 1'b0; // Register to hold completion status
+    // reg [3:0] count = 4'b0; // Counter to track the number of cycles
 
     always @(posedge clk or posedge rst) begin
         if (rst) begin

--- a/src/LFSR.v
+++ b/src/LFSR.v
@@ -1,4 +1,4 @@
-module LFSR (
+module LFSR_OLD (
     input [6:0] LFSR_SEED, // Load value
     input clk,
     input rst,

--- a/src/LFSR.v
+++ b/src/LFSR.v
@@ -16,11 +16,6 @@ module LFSR (
             //LFSR_out_next <= LFSR_SEED; // Load the seed value on reset
             complete_LFSR_reg <= 1'b0; // Reset completion status
             count <= 4'b0; // Reset the cycle counter
-        end else if (!enable) begin
-            // If not enabled, hold the current value
-            LFSR_out_next <= 7'b0; // Maintain current state
-            complete_LFSR_reg <= 0; // Maintain completion status
-            count <= 0; // Maintain cycle count
         end else if (enable && !complete_LFSR_reg) begin
             // If all zeros, reload the seed
             if (LFSR_out_next == 7'b0000000) begin

--- a/src/LFSR.v
+++ b/src/LFSR.v
@@ -16,7 +16,7 @@ module LFSR_OLD (
     reg [3:0] count; // Counter to track the number of cycles
 
 
-    always @(posedge clk or posedge rst) begin
+    always @(posedge clk) begin
         if (rst) begin
             LFSR_out_next <= LFSR_SEED; // Load the seed value on reset
             complete_LFSR_reg <= 1'b0; // Reset completion status

--- a/src/LFSR.v
+++ b/src/LFSR.v
@@ -18,7 +18,7 @@ module LFSR (
             count <= 4'b0; // Reset the cycle counter
         end else if (!enable) begin
             // If not enabled, hold the current value
-            LFSR_out_next <= 7'bz; // Maintain current state
+            LFSR_out_next <= 7'b0; // Maintain current state
             complete_LFSR_reg <= 0; // Maintain completion status
             count <= 0; // Maintain cycle count
         end else if (enable && !complete_LFSR_reg) begin

--- a/src/LFSR.v
+++ b/src/LFSR.v
@@ -18,7 +18,7 @@ module LFSR (
             count <= 4'b0; // Reset the cycle counter
         end else if (!enable) begin
             // If not enabled, hold the current value
-            LFSR_out_next <= 7'bzzzzzzz; // Maintain current state
+            LFSR_out_next <= 7'bz; // Maintain current state
             complete_LFSR_reg <= 0; // Maintain completion status
             count <= 0; // Maintain cycle count
         end else if (enable && !complete_LFSR_reg) begin

--- a/src/LFSR.v
+++ b/src/LFSR.v
@@ -11,6 +11,11 @@ module LFSR (
     // reg complete_LFSR_reg = 1'b0; // Register to hold completion status
     // reg [3:0] count = 4'b0; // Counter to track the number of cycles
 
+    reg [6:0] LFSR_out_next; // Next value to be assigned
+    reg complete_LFSR_reg; // Register to hold completion status
+    reg [3:0] count; // Counter to track the number of cycles
+
+
     always @(posedge clk or posedge rst) begin
         if (rst) begin
             LFSR_out_next <= LFSR_SEED; // Load the seed value on reset
@@ -25,12 +30,10 @@ module LFSR (
             end else begin
                 // 7-bit LFSR with taps at bits 7 and 6 (primitive polynomial x^7 + x^6 + 1)
                 LFSR_out_next <= {LFSR_out_next[5:0], LFSR_out_next[6] ^ LFSR_out_next[5]};
-                if (count < 7 && !complete_LFSR_reg) begin
-                    count <= count + 1;
-                    complete_LFSR_reg <= 1'b0;
-                end else if (count == 7) begin
-                    complete_LFSR_reg <= 1'b1; // Set complete after 8 shifts
-                end
+                    if (count < 6)
+                        count <= count + 1;
+                    else
+                        complete_LFSR_reg <= 1;
             end
         end
         // else: hold value (do nothing)

--- a/src/LFSR.v
+++ b/src/LFSR.v
@@ -1,9 +1,9 @@
-module LFSR_OLD (
-    input [6:0] LFSR_SEED, // Load value
+module LFSR (
+    input [7:0] LFSR_SEED, // Load value
     input clk,
     input rst,
     input enable,
-    output [6:0] LFSR_OUT,
+    output [7:0] LFSR_OUT,
     output complete_LFSR
 );
 
@@ -11,7 +11,7 @@ module LFSR_OLD (
     // reg complete_LFSR_reg = 1'b0; // Register to hold completion status
     // reg [3:0] count = 4'b0; // Counter to track the number of cycles
 
-    reg [6:0] LFSR_out_next; // Next value to be assigned
+    reg [7:0] LFSR_out_next; // Next value to be assigned
     reg complete_LFSR_reg; // Register to hold completion status
     reg [3:0] count; // Counter to track the number of cycles
 
@@ -23,13 +23,13 @@ module LFSR_OLD (
             count <= 4'b0; // Reset the cycle counter
         end else if (enable && !complete_LFSR_reg) begin
             // If all zeros, reload the seed
-            if (LFSR_out_next == 7'b0000000) begin
+            if (LFSR_out_next == 8'b00000000) begin
                 LFSR_out_next <= LFSR_SEED;
                 complete_LFSR_reg <= 1'b0;
                 count <= 4'b0;
             end else begin
                 // 7-bit LFSR with taps at bits 7 and 6 (primitive polynomial x^7 + x^6 + 1)
-                LFSR_out_next <= {LFSR_out_next[5:0], LFSR_out_next[6] ^ LFSR_out_next[5]};
+                LFSR_out_next <= {LFSR_out_next[5:0], LFSR_out_next[7] ^ LFSR_out_next[5] ^ LFSR_out_next[4] ^ LFSR_out_next[3]};
                     if (count < 6)
                         count <= count + 1;
                     else

--- a/src/LFSR.v
+++ b/src/LFSR.v
@@ -13,7 +13,7 @@ module LFSR (
 
     always @(posedge clk or posedge rst) begin
         if (rst) begin
-            //LFSR_out_next <= LFSR_SEED; // Load the seed value on reset
+            LFSR_out_next <= LFSR_SEED; // Load the seed value on reset
             complete_LFSR_reg <= 1'b0; // Reset completion status
             count <= 4'b0; // Reset the cycle counter
         end else if (enable && !complete_LFSR_reg) begin

--- a/src/LFSR.v
+++ b/src/LFSR.v
@@ -29,7 +29,7 @@ module LFSR (
                 count <= 4'b0;
             end else begin
                 // 7-bit LFSR with taps at bits 7 and 6 (primitive polynomial x^7 + x^6 + 1)
-                LFSR_out_next <= {LFSR_out_next[5:0], LFSR_out_next[7] ^ LFSR_out_next[5] ^ LFSR_out_next[4] ^ LFSR_out_next[3]};
+                LFSR_out_next <= {LFSR_out_next[6:0], LFSR_out_next[7] ^ LFSR_out_next[5] ^ LFSR_out_next[4] ^ LFSR_out_next[3]};
                     if (count < 6)
                         count <= count + 1;
                     else

--- a/src/LFSR_2.v
+++ b/src/LFSR_2.v
@@ -1,0 +1,72 @@
+module dff(output reg q, input d, input clk, input en);
+    always @(posedge clk) if (en) q <= d;
+endmodule
+
+module mux2to1 (
+    input wire sel,        // Select line
+    input wire a, b,       // Inputs
+    output wire y          // Output
+);
+
+assign y = sel ? b : a;    // If sel = 0, y = a; if sel = 1, y = b
+
+endmodule
+
+module t_flip_flop (
+    input wire clk,
+    input wire reset, // asynchronous reset
+    input wire T,
+    output reg Q
+);
+
+always @(posedge clk or posedge reset) begin
+    if (reset)
+        Q <= 1'b0;
+    else if (T)
+        Q <= ~Q; // Toggle
+    // else Q stays the same
+end
+
+endmodule
+
+
+module LFSR(
+    input  wire [6:0] LFSR_SEED, // Seed value to load
+    input  wire       clk,
+    input  wire       rst,
+    input  wire       enable,
+    output wire [6:0] LFSR_OUT,
+    output wire       complete_LFSR
+);
+
+
+wire next_bit = LFSR_OUT[6] ^ LFSR_OUT[5]; // Feedback calculation
+
+wire [6:0] D;
+wire [6:0] Q;
+wire counter;
+
+wire sel = rst || (Q == 7'b0000000);
+
+t_flip_flop tff(.clk(clk), .reset(rst), .T(1), .Q(counter));
+
+mux2to1 mux_0(sel, next_bit, LFSR_SEED[0], D[0]);
+mux2to1 mux_1(sel, Q[0], LFSR_SEED[1], D[1]);
+mux2to1 mux_2(sel, Q[1], LFSR_SEED[2], D[2]);
+mux2to1 mux_3(sel, Q[2], LFSR_SEED[3], D[3]);
+mux2to1 mux_4(sel, Q[3], LFSR_SEED[4], D[4]);
+mux2to1 mux_5(sel, Q[4], LFSR_SEED[5], D[5]);
+mux2to1 mux_6(sel, Q[5], LFSR_SEED[6], D[6]);
+
+dff dff_0(.q(Q[0]), .d(D[0]), .clk(clk), .en(enable));
+dff dff_1(.q(Q[1]), .d(D[1]), .clk(clk), .en(enable));
+dff dff_2(.q(Q[2]), .d(D[2]), .clk(clk), .en(enable));
+dff dff_3(.q(Q[3]), .d(D[3]), .clk(clk), .en(enable));
+dff dff_4(.q(Q[4]), .d(D[4]), .clk(clk), .en(enable));
+dff dff_5(.q(Q[5]), .d(D[5]), .clk(clk), .en(enable));
+dff dff_6(.q(Q[6]), .d(D[6]), .clk(clk), .en(enable));
+
+assign LFSR_OUT[6:0] = Q[6:0];
+assign complete_LFSR = counter == 1? 1'b1 : 1'b0;
+
+endmodule

--- a/src/LFSR_2.v
+++ b/src/LFSR_2.v
@@ -2,34 +2,6 @@ module dff(output reg q, input d, input clk, input en);
     always @(posedge clk) if (en) q <= d;
 endmodule
 
-module mux2to1 (
-    input wire sel,        // Select line
-    input wire a, b,       // Inputs
-    output wire y          // Output
-);
-
-assign y = sel ? b : a;    // If sel = 0, y = a; if sel = 1, y = b
-
-endmodule
-
-module t_flip_flop (
-    input wire clk,
-    input wire reset, // asynchronous reset
-    input wire T,
-    output reg Q
-);
-
-always @(posedge clk or posedge reset) begin
-    if (reset)
-        Q <= 1'b0;
-    else if (T)
-        Q <= ~Q; // Toggle
-    // else Q stays the same
-end
-
-endmodule
-
-
 module LFSR(
     input  wire [6:0] LFSR_SEED, // Seed value to load
     input  wire       clk,

--- a/src/LFSR_tb.v
+++ b/src/LFSR_tb.v
@@ -12,7 +12,7 @@ wire feedback;
 assign feedback = LFSR_OUT[7] ^ LFSR_OUT[5] ^ LFSR_OUT[4] ^ LFSR_OUT[3];
 
 // Instantiate the LFSR module
-LFSR_OLD uut (
+LFSR uut (
     .LFSR_SEED(LFSR_SEED),
     .clk(clk),
     .rst(rst),

--- a/src/LFSR_tb.v
+++ b/src/LFSR_tb.v
@@ -3,16 +3,16 @@ module test;
 // Signals for LFSR
 reg rst = 0;
 reg enable = 1;
-reg [6:0] LFSR_SEED = 7'b1101001; // Example seed
-wire [6:0] LFSR_OUT;
+reg [7:0] LFSR_SEED = 8'b11010011; // Example 8-bit seed
+wire [7:0] LFSR_OUT;
 wire complete_LFSR;
 
 // Internal signal to observe feedback calculation
 wire feedback;
-assign feedback = LFSR_OUT[6] ^ LFSR_OUT[5];
+assign feedback = LFSR_OUT[7] ^ LFSR_OUT[5] ^ LFSR_OUT[4] ^ LFSR_OUT[3];
 
 // Instantiate the LFSR module
-LFSR uut (
+LFSR_OLD uut (
     .LFSR_SEED(LFSR_SEED),
     .clk(clk),
     .rst(rst),
@@ -31,23 +31,23 @@ initial begin
     $dumpvars(0, test);
 
     #1 enable = 1;
-    #90 rst = 1; // Reset the LFSR
-    #1 rst = 0;
+    #10 rst = 1; // Reset the LFSR
+    #2 rst = 0;
 
-    #100 enable = 0;
-    // #17 rst = 1;
-    // #11 rst = 0;
-    // #29 rst = 1;
-    // #5  rst = 0;
+    #40 rst = 1;
+    #2 rst = 0;
 
-    // #20 enable = 0;
-    // #20 enable = 1;
-    #513 $finish;
+    // Run with enable high for 20 cycles
+    #40 enable = 0;
+    // Hold for 10 cycles
+    #20 enable = 1;
+    // Run for 40 more cycles
+    #80 $finish;
 end
 
 // Monitor outputs and XOR feedback
 always @(posedge clk) begin
-    $display("At time %t, LFSR_OUT = %b, feedback (LFSR_OUT[6] ^ LFSR_OUT[5]) = %b, complete_LFSR = %b", 
+    $display("At time %t, LFSR_OUT = %b, feedback (LFSR_OUT[7]^LFSR_OUT[5]^LFSR_OUT[4]^LFSR_OUT[3]) = %b, complete_LFSR = %b", 
         $time, LFSR_OUT, feedback, complete_LFSR);
 end
 

--- a/src/LFSR_tb.v
+++ b/src/LFSR_tb.v
@@ -1,0 +1,54 @@
+module test;
+
+// Signals for LFSR
+reg rst = 0;
+reg enable = 1;
+reg [6:0] LFSR_SEED = 7'b1101001; // Example seed
+wire [6:0] LFSR_OUT;
+wire complete_LFSR;
+
+// Internal signal to observe feedback calculation
+wire feedback;
+assign feedback = LFSR_OUT[6] ^ LFSR_OUT[5];
+
+// Instantiate the LFSR module
+LFSR uut (
+    .LFSR_SEED(LFSR_SEED),
+    .clk(clk),
+    .rst(rst),
+    .enable(enable),
+    .LFSR_OUT(LFSR_OUT),
+    .complete_LFSR(complete_LFSR)
+);
+
+// Clock generation
+reg clk = 0;
+always #1 clk = ~clk;
+
+// Test sequence
+initial begin
+    $dumpfile("LFSR_test.vcd");
+    $dumpvars(0, test);
+
+    #1 enable = 1;
+    #90 rst = 1; // Reset the LFSR
+    #1 rst = 0;
+
+    #100 enable = 0;
+    // #17 rst = 1;
+    // #11 rst = 0;
+    // #29 rst = 1;
+    // #5  rst = 0;
+
+    // #20 enable = 0;
+    // #20 enable = 1;
+    #513 $finish;
+end
+
+// Monitor outputs and XOR feedback
+always @(posedge clk) begin
+    $display("At time %t, LFSR_OUT = %b, feedback (LFSR_OUT[6] ^ LFSR_OUT[5]) = %b, complete_LFSR = %b", 
+        $time, LFSR_OUT, feedback, complete_LFSR);
+end
+
+endmodule //test

--- a/src/project.v
+++ b/src/project.v
@@ -13,12 +13,12 @@ module tt_um_simonsays (
 );
 
     // Instantiate only the LFSR_OLD module and connect all I/O
-    LFSR_OLD lfsr_inst (
-        .LFSR_SEED(ui_in[6:0]),      // Use the first 7 bits of ui_in as the seed
+    LFSR lfsr_inst (
+        .LFSR_SEED(ui_in[7:0]),      // Use the first 7 bits of ui_in as the seed
         .clk(clk),
         .rst(~rst_n),                // Active low reset
         .enable(ena),                // Enable signal
-        .LFSR_OUT(uio_out[6:0]),     // Output the LFSR value to uio_out[6:0]
+        .LFSR_OUT(uio_out[7:0]),     // Output the LFSR value to uio_out[6:0]
         .complete_LFSR(uio_out[7])   // Indicate completion in the last bit of uio_out
     );
 

--- a/src/project.v
+++ b/src/project.v
@@ -1,4 +1,4 @@
-module counter (
+module tt_um_simonsays (
     input  wire        clk,        // System clock
     input  wire        rst_n,      // Active-low synchronous reset
     input  wire        load,       // Parallel load enable (synchronous)

--- a/src/project.v
+++ b/src/project.v
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) 2024 Your Name
- * SPDX-License-Identifier: Apache-2.0
- */
 
 `default_nettype none
 
@@ -16,105 +12,18 @@ module tt_um_simonsays (
     input  wire       rst_n     // reset_n - low to reset
 );
 
-  wire load = uio_in;
-  wire [7:0] base = ui_in[7:0]; 
-  wire T_0, T_1, T_2, T_3, T_4, T_5, T_6, T_7;
-  wire Q_0, Q_1, Q_2, Q_3, Q_4, Q_5, Q_6, Q_7;
-  wire ena_0, ena_1, ena_2, ena_3, ena_4, ena_5, ena_6, ena_7;
-  wire l0, l1, l2, l3, l4, l5, l6, l7;
-  wire lfsr_complete;
-
-
-  assign l0 = base[0] ^ Q_0;
-  assign l1 = base[1] ^ Q_1;
-    assign l2 = base[2] ^ Q_2;  
-    assign l3 = base[3] ^ Q_3;
-    assign l4 = base[4] ^ Q_4;
-    assign l5 = base[5] ^ Q_5;
-    assign l6 = base[6] ^ Q_6;
-    assign l7 = base[7] ^ Q_7;
-
-
-
-  assign ena_0 = ena;
-  assign ena_1 = ena && Q_0;
-  assign ena_2 = ena && Q_0 && Q_1;
-  assign ena_3 = ena && Q_0 && Q_1 && Q_2;
-  assign ena_4 = ena && Q_0 && Q_1 && Q_2 && Q_3;
-  assign ena_5 = ena && Q_0 && Q_1 && Q_2 && Q_3 && Q_4;
-  assign ena_6 = ena && Q_0 && Q_1 && Q_2 && Q_3 && Q_4 && Q_5;
-  assign ena_7 = ena && Q_0 && Q_1 && Q_2 && Q_3 && Q_4 && Q_5 && Q_6;
-
-
-  
-  // Instantiate T flip-flops
-
-  t_flip_flop tff_0(.clk(clk), .reset(~rst_n), .T(T_0), .Q(Q_0));
-  t_flip_flop tff_1(.clk(clk), .reset(~rst_n), .T(T_1), .Q(Q_1));
-  t_flip_flop tff_2(.clk(clk), .reset(~rst_n), .T(T_2), .Q(Q_2));
-  t_flip_flop tff_3(.clk(clk), .reset(~rst_n), .T(T_3), .Q(Q_3));
-  t_flip_flop tff_4(.clk(clk), .reset(~rst_n), .T(T_4), .Q(Q_4));
-  t_flip_flop tff_5(.clk(clk), .reset(~rst_n), .T(T_5), .Q(Q_5));
-  t_flip_flop tff_6(.clk(clk), .reset(~rst_n), .T(T_6), .Q(Q_6));
-  t_flip_flop tff_7(.clk(clk), .reset(~rst_n), .T(T_7), .Q(Q_7));
-
-    // Instantiate 8 2-to-1 multiplexers
-
-  mux2to1 mux_0(.sel(load), .a(ena_0), .b(l0), .y(T_0));
-  mux2to1 mux_1(.sel(load), .a(ena_1), .b(l1), .y(T_1));
-  mux2to1 mux_2(.sel(load), .a(ena_2), .b(l2), .y(T_2));
-  mux2to1 mux_3(.sel(load), .a(ena_3), .b(l3), .y(T_3));
-  mux2to1 mux_4(.sel(load), .a(ena_4), .b(l4), .y(T_4));
-  mux2to1 mux_5(.sel(load), .a(ena_5), .b(l5), .y(T_5));
-  mux2to1 mux_6(.sel(load), .a(ena_6), .b(l6), .y(T_6));
-  mux2to1 mux_7(.sel(load), .a(ena_7), .b(l7), .y(T_7));
-  
+    // Instantiate only the LFSR_OLD module and connect all I/O
     LFSR_OLD lfsr_inst (
-        .LFSR_SEED(ui_in[6:0]), // Use the first 7 bits of ui_in as the seed
+        .LFSR_SEED(ui_in[6:0]),      // Use the first 7 bits of ui_in as the seed
         .clk(clk),
-        .rst(~rst_n), // Active low reset
-        .enable(ena), // Enable signal
-        .LFSR_OUT(uio_out[6:0]), // Output the LFSR value to uio_out
-        .complete_LFSR(uio_out[7]) // Indicate completion in the last bit of uio_out
+        .rst(~rst_n),                // Active low reset
+        .enable(ena),                // Enable signal
+        .LFSR_OUT(uio_out[6:0]),     // Output the LFSR value to uio_out[6:0]
+        .complete_LFSR(uio_out[7])   // Indicate completion in the last bit of uio_out
     );
 
-  
-
-  // All output pins must be assigned. If not used, assign to 0.
-  // assign uo_out  = ui_in + uio_in;  // Example: ou_out is the sum of ui_in and uio_in
-  assign uo_out = ena? {Q_7, Q_6, Q_5, Q_4, Q_3, Q_2, Q_1, Q_0} : 8'bz; // Example: ou_out is the output of the T flip-flop
-  assign uio_oe  = 0;
-
-  // List all unused inputs to prevent warnings
-  wire _unused = &{ena, clk, rst_n, 1'b0};
-
-endmodule
-
-
-module t_flip_flop (
-    input wire clk,
-    input wire reset, // asynchronous reset
-    input wire T,
-    output reg Q
-);
-
-always @(posedge clk or posedge reset) begin
-    if (reset)
-        Q <= 1'b0;
-    else if (T)
-        Q <= ~Q; // Toggle
-    // else Q stays the same
-end
-
-endmodule
-
-
-module mux2to1 (
-    input wire sel,        // Select line
-    input wire a, b,       // Inputs
-    output wire y          // Output
-);
-
-assign y = sel ? b : a;    // If sel = 0, y = a; if sel = 1, y = b
+    // All output pins must be assigned. If not used, assign to 0.
+    assign uo_out  = 8'b0;
+    assign uio_oe  = 8'b1111_1111; // All uio_out pins are outputs
 
 endmodule

--- a/src/project.v
+++ b/src/project.v
@@ -22,6 +22,7 @@ module tt_um_simonsays (
   wire Q_0, Q_1, Q_2, Q_3, Q_4, Q_5, Q_6, Q_7;
   wire ena_0, ena_1, ena_2, ena_3, ena_4, ena_5, ena_6, ena_7;
   wire l0, l1, l2, l3, l4, l5, l6, l7;
+  wire lfsr_complete;
 
 
   assign l0 = base[0] ^ Q_0;
@@ -82,7 +83,6 @@ module tt_um_simonsays (
   // All output pins must be assigned. If not used, assign to 0.
   // assign uo_out  = ui_in + uio_in;  // Example: ou_out is the sum of ui_in and uio_in
   assign uo_out = ena? {Q_7, Q_6, Q_5, Q_4, Q_3, Q_2, Q_1, Q_0} : 8'bz; // Example: ou_out is the output of the T flip-flop
-  assign uio_out = 0;
   assign uio_oe  = 0;
 
   // List all unused inputs to prevent warnings

--- a/src/project.v
+++ b/src/project.v
@@ -12,18 +12,20 @@ module tt_um_simonsays (
     input  wire       rst_n     // reset_n - low to reset
 );
 
+  wire lfsr_comp;
+  
     // Instantiate only the LFSR_OLD module and connect all I/O
     LFSR lfsr_inst (
         .LFSR_SEED(ui_in[7:0]),      // Use the first 7 bits of ui_in as the seed
         .clk(clk),
         .rst(~rst_n),                // Active low reset
         .enable(ena),                // Enable signal
-        .LFSR_OUT(uio_out[7:0]),     // Output the LFSR value to uio_out[6:0]
-        .complete_LFSR(uio_out[7])   // Indicate completion in the last bit of uio_out
+        .LFSR_OUT(uo_out[7:0]),     // Output the LFSR value to uio_out[6:0]
+        .complete_LFSR(lfsr_comp)   // Indicate completion in the last bit of uio_out
     );
 
     // All output pins must be assigned. If not used, assign to 0.
-    assign uo_out  = 8'b0;
+    assign uio_out  = {7'b0, lfsr_comp};
     assign uio_oe  = 8'b1111_1111; // All uio_out pins are outputs
 
 endmodule

--- a/src/project.v
+++ b/src/project.v
@@ -118,4 +118,3 @@ module mux2to1 (
 assign y = sel ? b : a;    // If sel = 0, y = a; if sel = 1, y = b
 
 endmodule
-  

--- a/src/project.v
+++ b/src/project.v
@@ -69,7 +69,7 @@ module tt_um_simonsays (
   mux2to1 mux_6(.sel(load), .a(ena_6), .b(l6), .y(T_6));
   mux2to1 mux_7(.sel(load), .a(ena_7), .b(l7), .y(T_7));
   
-    LFSR lfsr_inst (
+    LFSR_OLD lfsr_inst (
         .LFSR_SEED(ui_in[6:0]), // Use the first 7 bits of ui_in as the seed
         .clk(clk),
         .rst(~rst_n), // Active low reset

--- a/src/project.v
+++ b/src/project.v
@@ -9,8 +9,19 @@ module counter (
 );
 
     // Internal register to hold the count value
-    reg [7:0] count_reg;
+    //reg [7:0] count_reg;
 
+    //test instantiate lfsr
+    LFSR lfsr_inst (
+        .LFSR_SEED(lfsr_seed),
+        .clk(clk),
+        .rst(~rst_n),        // Assuming LFSR uses active-high reset
+        .enable(clk_en),     // Or another enable signal as appropriate
+        .LFSR_OUT(lfsr_out),
+        .complete_LFSR(lfsr_complete)
+    );
+
+    /*
     // Synchronous process: reset, load, or count
     always @(posedge clk) begin
         if (!rst_n) begin
@@ -25,5 +36,6 @@ module counter (
 
     // Tri-state driver: when oe=1, drive count_reg; when oe=0, high-impedance
     assign bus = (oe) ? count_reg : 8'bz;
+    */
 
 endmodule

--- a/src/project.v
+++ b/src/project.v
@@ -1,41 +1,121 @@
+/*
+ * Copyright (c) 2024 Your Name
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+`default_nettype none
+
 module tt_um_simonsays (
-    input  wire        clk,        // System clock
-    input  wire        rst_n,      // Active-low synchronous reset
-    input  wire        load,       // Parallel load enable (synchronous)
-    input  wire        clk_en,     // Count enable (synchronous)
-    input  wire [7:0]  load_data,  // Data to be loaded in parallel
-    input  wire        oe,         // Output enable (when 1, outputs drive; when 0, Z)
-    output wire [7:0]  bus         // Tri-state bus
+    input  wire [7:0] ui_in,    // Dedicated inputs
+    output wire [7:0] uo_out,   // Dedicated outputs
+    input  wire [7:0] uio_in,   // IOs: Input path
+    output wire [7:0] uio_out,  // IOs: Output path
+    output wire [7:0] uio_oe,   // IOs: Enable path (active high: 0=input, 1=output)
+    input  wire       ena,      // always 1 when the design is powered, so you can ignore it
+    input  wire       clk,      // clock
+    input  wire       rst_n     // reset_n - low to reset
 );
 
-    // Internal register to hold the count value
-    //reg [7:0] count_reg;
+  wire load = uio_in;
+  wire [7:0] base = ui_in[7:0]; 
+  wire T_0, T_1, T_2, T_3, T_4, T_5, T_6, T_7;
+  wire Q_0, Q_1, Q_2, Q_3, Q_4, Q_5, Q_6, Q_7;
+  wire ena_0, ena_1, ena_2, ena_3, ena_4, ena_5, ena_6, ena_7;
+  wire l0, l1, l2, l3, l4, l5, l6, l7;
 
-    //test instantiate lfsr
+
+  assign l0 = base[0] ^ Q_0;
+  assign l1 = base[1] ^ Q_1;
+    assign l2 = base[2] ^ Q_2;  
+    assign l3 = base[3] ^ Q_3;
+    assign l4 = base[4] ^ Q_4;
+    assign l5 = base[5] ^ Q_5;
+    assign l6 = base[6] ^ Q_6;
+    assign l7 = base[7] ^ Q_7;
+
+
+
+  assign ena_0 = ena;
+  assign ena_1 = ena && Q_0;
+  assign ena_2 = ena && Q_0 && Q_1;
+  assign ena_3 = ena && Q_0 && Q_1 && Q_2;
+  assign ena_4 = ena && Q_0 && Q_1 && Q_2 && Q_3;
+  assign ena_5 = ena && Q_0 && Q_1 && Q_2 && Q_3 && Q_4;
+  assign ena_6 = ena && Q_0 && Q_1 && Q_2 && Q_3 && Q_4 && Q_5;
+  assign ena_7 = ena && Q_0 && Q_1 && Q_2 && Q_3 && Q_4 && Q_5 && Q_6;
+
+
+  
+  // Instantiate T flip-flops
+
+  t_flip_flop tff_0(.clk(clk), .reset(~rst_n), .T(T_0), .Q(Q_0));
+  t_flip_flop tff_1(.clk(clk), .reset(~rst_n), .T(T_1), .Q(Q_1));
+  t_flip_flop tff_2(.clk(clk), .reset(~rst_n), .T(T_2), .Q(Q_2));
+  t_flip_flop tff_3(.clk(clk), .reset(~rst_n), .T(T_3), .Q(Q_3));
+  t_flip_flop tff_4(.clk(clk), .reset(~rst_n), .T(T_4), .Q(Q_4));
+  t_flip_flop tff_5(.clk(clk), .reset(~rst_n), .T(T_5), .Q(Q_5));
+  t_flip_flop tff_6(.clk(clk), .reset(~rst_n), .T(T_6), .Q(Q_6));
+  t_flip_flop tff_7(.clk(clk), .reset(~rst_n), .T(T_7), .Q(Q_7));
+
+    // Instantiate 8 2-to-1 multiplexers
+
+  mux2to1 mux_0(.sel(load), .a(ena_0), .b(l0), .y(T_0));
+  mux2to1 mux_1(.sel(load), .a(ena_1), .b(l1), .y(T_1));
+  mux2to1 mux_2(.sel(load), .a(ena_2), .b(l2), .y(T_2));
+  mux2to1 mux_3(.sel(load), .a(ena_3), .b(l3), .y(T_3));
+  mux2to1 mux_4(.sel(load), .a(ena_4), .b(l4), .y(T_4));
+  mux2to1 mux_5(.sel(load), .a(ena_5), .b(l5), .y(T_5));
+  mux2to1 mux_6(.sel(load), .a(ena_6), .b(l6), .y(T_6));
+  mux2to1 mux_7(.sel(load), .a(ena_7), .b(l7), .y(T_7));
+  
     LFSR lfsr_inst (
-        .LFSR_SEED(lfsr_seed),
+        .LFSR_SEED(ui_in[6:0]), // Use the first 7 bits of ui_in as the seed
         .clk(clk),
-        .rst(~rst_n),        // Assuming LFSR uses active-high reset
-        .enable(clk_en),     // Or another enable signal as appropriate
-        .LFSR_OUT(lfsr_out),
-        .complete_LFSR(lfsr_complete)
+        .rst(~rst_n), // Active low reset
+        .enable(ena), // Enable signal
+        .LFSR_OUT(uio_out[6:0]), // Output the LFSR value to uio_out
+        .complete_LFSR(uio_out[7]) // Indicate completion in the last bit of uio_out
     );
 
-    /*
-    // Synchronous process: reset, load, or count
-    always @(posedge clk) begin
-        if (!rst_n) begin
-            count_reg <= 8'b0;
-        end else if (load) begin
-            count_reg <= load_data;
-        end else if (clk_en) begin
-            count_reg <= count_reg + 1'b1;
-        end
-        // If neither reset, load, nor clk_en, hold current value
-    end
+  
 
-    // Tri-state driver: when oe=1, drive count_reg; when oe=0, high-impedance
-    assign bus = (oe) ? count_reg : 8'bz;
-    */
+  // All output pins must be assigned. If not used, assign to 0.
+  // assign uo_out  = ui_in + uio_in;  // Example: ou_out is the sum of ui_in and uio_in
+  assign uo_out = ena? {Q_7, Q_6, Q_5, Q_4, Q_3, Q_2, Q_1, Q_0} : 8'bz; // Example: ou_out is the output of the T flip-flop
+  assign uio_out = 0;
+  assign uio_oe  = 0;
+
+  // List all unused inputs to prevent warnings
+  wire _unused = &{ena, clk, rst_n, 1'b0};
 
 endmodule
+
+
+module t_flip_flop (
+    input wire clk,
+    input wire reset, // asynchronous reset
+    input wire T,
+    output reg Q
+);
+
+always @(posedge clk or posedge reset) begin
+    if (reset)
+        Q <= 1'b0;
+    else if (T)
+        Q <= ~Q; // Toggle
+    // else Q stays the same
+end
+
+endmodule
+
+
+module mux2to1 (
+    input wire sel,        // Select line
+    input wire a, b,       // Inputs
+    output wire y          // Output
+);
+
+assign y = sel ? b : a;    // If sel = 0, y = a; if sel = 1, y = b
+
+endmodule
+  


### PR DESCRIPTION

This PR adds an LFSR module that implements an 8-bit linear feedback shift register with a configurable seed and completion detection logic.

- 8-bit LFSR with seed input (LFSR_SEED)
- Feedback taps on bits 7, 5, 4, and 3 (based on a primitive polynomial)
- Operates on posedge clk with enable and active-high rst
- Automatically resets and reloads the seed if the LFSR state hits all zeroes

Inputs/Outputs
- input  [7:0] LFSR_SEED   // Seed value to initialize LFSR
- input        clk         // Clock signal
- input        rst         // Reset (active high)
- input        enable      // Enable shift
- output [7:0] LFSR_OUT    // Current LFSR state
- output       complete_LFSR // High after 7 cycles