### PR TITLE
Idle State

### DIFF
--- a/info.yaml
+++ b/info.yaml
@@ -18,8 +18,8 @@ project:
   # Don't forget to also update `PROJECT_SOURCES` in test/Makefile.
   source_files:
     - "project.v"
-    # - "LFSR_2.v"
     - "LFSR.v"
+    - "idle_state.v"
 
 # The pinout of your project. Leave unused pins blank. DO NOT delete or add any pins.
 # This section is for the datasheet/website. Use descriptive names (e.g., RX, TX, MOSI, SCL, SEG_A, etc.).

--- a/src/idle_state.v
+++ b/src/idle_state.v
@@ -3,48 +3,46 @@ module IDLE_STATE(
     input wire en_IDLE,
     input wire rst_IDLE,
     input wire complete_LFSR,
-    input wire [6:0] LFSR_output,
-    output wire en_LFSR,
-    output wire [6:0] 32b_MEM_IN,
-    output wire 32b_MEM_LOAD,
-    output wire complete_IDLE
-    output wire 32b_MEM_LOAD_VAL
-)
+    input wire [7:0] LFSR_output,
+    output reg en_LFSR,
+    output reg [7:0] MEM_IN,
+    output reg MEM_LOAD,
+    output reg complete_IDLE,
+    output reg [1:0]MEM_LOAD_VAL
+);
 
-wire [1:0] count = 2'b00; 
+reg [1:0] count;
 
-always @(posedge clk)begin
-    if(rst_IDLE)
+always @(posedge clk) begin
+    if (rst_IDLE) begin
         en_LFSR <= 1'b0;
-        32b_MEM_IN <= 32'b0;
-        32b_MEM_LOAD <= 1'b0;
+        MEM_IN <= 8'b0;
+        MEM_LOAD <= 1'b0;
         complete_IDLE <= 1'b0;
         count <= 2'b00;
-    else if(en_IDLE) 
-        if(complete_LFSR && ~32b_MEM_LOAD) // lfsr is done shifting (ie valid value on lfsr output), and has not been loaded to mem.
-            begin
-                en_LFSR <= 1'b0; // disable LFSR to stop further shifting
-                32b_MEM_IN <= LFSR_output; // load the lfsr output into the mem
-                32b_MEM_LOAD_VAL <= count; // set the load value to current count
-                32b_MEM_LOAD <= 1'b1; // enable mem load
-            end
-        else if(32b_MEM_LOAD) begin
-            // may need to reset lfsr counter ??
-            en_LFSR <= 1'b1; // reenable lfsr 
-            32b_MEM_LOAD <= 1'b0; // reset mem load signal
-            if(count == 2'b00) count <= 2'b01; // increment count
-            else if(count == 2'b01) count <= 2'b10; // increment count
-            else if(count == 2'b10) count <= 2'b11; // increment count
-            else if(count == 2'b11) begin
-                complete_IDLE <= 1'b1; // set complete signal when all bits loaded
-                count <= 2'b00; // reset count for next cycle
-            end else begin
-                complete_IDLE <= 1'b0; // reset complete signal if not done
-        end
-        else begin
-            en_LFSR <= 1'b1; // keep LFSR enabled for next cycle
-        end
+    end else if (en_IDLE) begin
+        if (complete_LFSR && ~MEM_LOAD) begin
+            en_LFSR <= 1'b0;
+            MEM_IN <= LFSR_output;
+            MEM_LOAD_VAL <= count;
+            MEM_LOAD <= 1'b1;
+        end else if (MEM_LOAD) begin
+            en_LFSR <= 1'b1;
+            MEM_LOAD <= 1'b0;
 
-            
+            if (count == 2'b00) count <= 2'b01;
+            else if (count == 2'b01) count <= 2'b10;
+            else if (count == 2'b10) count <= 2'b11;
+            else if (count == 2'b11) begin
+                complete_IDLE <= 1'b1;
+                count <= 2'b00;
+            end else begin
+                complete_IDLE <= 1'b0;
+            end // <- missing END added here!
+        end else begin
+            en_LFSR <= 1'b1;
+        end
+    end
+end
 
 endmodule

--- a/src/idle_state.v
+++ b/src/idle_state.v
@@ -5,10 +5,13 @@ module IDLE_STATE(
     input wire complete_LFSR,
     input wire [6:0] LFSR_output,
     output wire en_LFSR,
-    output wire [31:0] 32b_MEM_IN,
+    output wire [6:0] 32b_MEM_IN,
     output wire 32b_MEM_LOAD,
     output wire complete_IDLE
+    output wire 32b_MEM_LOAD_VAL
 )
+
+wire [1:0] count = 2'b00; 
 
 always @(posedge clk or posedge rst_IDLE)begin
     if(rst)
@@ -16,11 +19,32 @@ always @(posedge clk or posedge rst_IDLE)begin
         32b_MEM_IN <= 32'b0;
         32b_MEM_LOAD <= 1'b0;
         complete_IDLE <= 1'b0;
+        count <= 2'b00;
     else if(en_IDLE) 
-        if(complete_LFSR && ~32b_MEM_LOAD)
-            // en_LFSR <= 1'b0;
-            // 32b_MEM_IN <= {25'b0, LFSR_output};
-            // 32b_MEM_LOAD <= 1'b1;
-            // complete_IDLE <= 1'b1;
+        if(complete_LFSR && ~32b_MEM_LOAD) // lfsr is done shifting (ie valid value on lfsr output), and has not been loaded to mem.
+            begin
+                en_LFSR <= 1'b0; // disable LFSR to stop further shifting
+                32b_MEM_IN <= LFSR_output; // load the lfsr output into the mem
+                32b_MEM_LOAD_VAL <= count; // set the load value to current count
+                32b_MEM_LOAD <= 1'b1; // enable mem load
+            end
+        else if(32b_MEM_LOAD) begin
+            // may need to reset lfsr counter ??
+            en_LFSR <= 1'b1; // reenable lfsr 
+            32b_MEM_LOAD <= 1'b0; // reset mem load signal
+            if(count == 2'b00) count <= 2'b01; // increment count
+            else if(count == 2'b01) count <= 2'b10; // increment count
+            else if(count == 2'b10) count <= 2'b11; // increment count
+            else if(count == 2'b11) begin
+                complete_IDLE <= 1'b1; // set complete signal when all bits loaded
+                count <= 2'b00; // reset count for next cycle
+            end else begin
+                complete_IDLE <= 1'b0; // reset complete signal if not done
+        end
+        else begin
+            en_LFSR <= 1'b1; // keep LFSR enabled for next cycle
+        end
+
+            
 
 endmodule

--- a/src/idle_state.v
+++ b/src/idle_state.v
@@ -1,0 +1,26 @@
+module IDLE_STATE(
+    input wire clk,
+    input wire en_IDLE,
+    input wire rst_IDLE,
+    input wire complete_LFSR,
+    input wire [6:0] LFSR_output,
+    output wire en_LFSR,
+    output wire [31:0] 32b_MEM_IN,
+    output wire 32b_MEM_LOAD,
+    output wire complete_IDLE
+)
+
+always @(posedge clk or posedge rst_IDLE)begin
+    if(rst)
+        en_LFSR <= 1'b0;
+        32b_MEM_IN <= 32'b0;
+        32b_MEM_LOAD <= 1'b0;
+        complete_IDLE <= 1'b0;
+    else if(en_IDLE) 
+        if(complete_LFSR && ~32b_MEM_LOAD)
+            // en_LFSR <= 1'b0;
+            // 32b_MEM_IN <= {25'b0, LFSR_output};
+            // 32b_MEM_LOAD <= 1'b1;
+            // complete_IDLE <= 1'b1;
+
+endmodule

--- a/src/idle_state.v
+++ b/src/idle_state.v
@@ -13,8 +13,8 @@ module IDLE_STATE(
 
 wire [1:0] count = 2'b00; 
 
-always @(posedge clk or posedge rst_IDLE)begin
-    if(rst)
+always @(posedge clk)begin
+    if(rst_IDLE)
         en_LFSR <= 1'b0;
         32b_MEM_IN <= 32'b0;
         32b_MEM_LOAD <= 1'b0;

--- a/src/idle_state_tb.v
+++ b/src/idle_state_tb.v
@@ -1,0 +1,83 @@
+`timescale 1ns/1ps
+
+module idle_state_tb;
+
+    reg clk = 0;
+    reg en_IDLE = 0;
+    reg rst_IDLE = 0;
+    reg complete_LFSR = 0;
+    reg [31:0] lfsr_sequence = 32'hA5B6C7D8; // Example 32-bit value to output 8 bits at a time
+    reg [7:0] LFSR_output = 8'h00;
+
+    wire en_LFSR;
+    wire [7:0] MEM_IN;
+    wire MEM_LOAD;
+    wire complete_IDLE;
+    wire [1:0] MEM_LOAD_VAL;
+
+    // Instantiate the DUT
+    IDLE_STATE dut (
+        .clk(clk),
+        .en_IDLE(en_IDLE),
+        .rst_IDLE(rst_IDLE),
+        .complete_LFSR(complete_LFSR),
+        .LFSR_output(LFSR_output),
+        .en_LFSR(en_LFSR),
+        .MEM_IN(MEM_IN),
+        .MEM_LOAD(MEM_LOAD),
+        .complete_IDLE(complete_IDLE),
+        .MEM_LOAD_VAL(MEM_LOAD_VAL)
+    );
+
+    // Clock generation
+    always #5 clk = ~clk;
+
+    initial begin
+        $dumpfile("idle_state_tb.vcd");
+        $dumpvars(0, idle_state_tb);
+
+        // Initial reset
+        rst_IDLE = 1;
+        en_IDLE = 0;
+        complete_LFSR = 0;
+        #12;
+        rst_IDLE = 0;
+        en_IDLE = 1;
+
+        // Simulate 4 LFSR loads, outputting 8 bits at a time from lfsr_sequence
+        repeat (5) begin
+            @(negedge clk);
+            // Assign the next 8 bits of lfsr_sequence based on MEM_LOAD_VAL
+            case (MEM_LOAD_VAL)
+                2'b00: LFSR_output = lfsr_sequence[7:0];
+                2'b01: LFSR_output = lfsr_sequence[15:8];
+                2'b10: LFSR_output = lfsr_sequence[23:16];
+                2'b11: LFSR_output = lfsr_sequence[31:24];
+                default: LFSR_output = 8'h00;
+            endcase
+            complete_LFSR = 1;
+            @(negedge clk);
+            complete_LFSR = 0;
+            // Wait for MEM_LOAD to go high and then low
+            wait (MEM_LOAD == 1);
+            $display("LFSR load output: %h, MEM_IN: %h, LOAD_VAL:%b", LFSR_output, MEM_IN, MEM_LOAD_VAL);
+            @(negedge clk);
+            wait (MEM_LOAD == 0);
+        end
+
+        // Wait for complete_IDLE to go high
+        wait (complete_IDLE == 1);
+        $display("IDLE state complete!");
+
+        #20;
+        $finish;
+    end
+
+    // Monitor signals
+    initial begin
+        $display("Time\tclk\ten_IDLE\trst_IDLE\tcomplete_LFSR\tLFSR_output\tMEM_IN\tMEM_LOAD\tcomplete_IDLE\tMEM_LOAD_VAL\ten_LFSR");
+        $monitor("%0t\t%b\t%b\t%b\t%b\t%h\t%h\t%b\t%b\t%b\t%b",
+            $time, clk, en_IDLE, rst_IDLE, complete_LFSR, LFSR_output, MEM_IN, MEM_LOAD, complete_IDLE, MEM_LOAD_VAL, en_LFSR);
+    end
+
+endmodule

--- a/src/project.v
+++ b/src/project.v
@@ -25,9 +25,9 @@ module tt_um_simonsays (
     wire en_LFSR;
 
     //IDLE 
-    wire en_IDLE;
-    wire rst_IDLE;
-    wire complete_IDLE;
+    wire en_IDLE = ui_in[6]; // temp
+    wire rst_IDLE = ui_in[6]; // temp
+    wire complete_IDLE = ui_in[6]; // temp
 
     //32bMEM
     wire MEM_LOAD;
@@ -38,7 +38,7 @@ module tt_um_simonsays (
     LFSR lfsr(
         .LFSR_SEED(LFSR_SEED),      // Use the first 7 bits of ui_in as the seed
         .clk(clk),
-        .rst(rst_n),                // Active low reset
+        .rst(~rst_n),                // Active low reset
         .enable(ena),                // Enable signal
         .LFSR_OUT(LFSR_out),     // Output the LFSR value to uio_out[6:0]
         .complete_LFSR(complete_LFSR)   // Indicate completion in the last bit of uio_out
@@ -61,4 +61,5 @@ module tt_um_simonsays (
     // All output pins must be assigned. If not used, assign to 0.
     assign uo_out  = MEM_IN;
     assign uio_oe  = 8'b1111_1111; // All uio_out pins are outputs
+    assign uio_out = 8'b0;
 endmodule

--- a/src/project.v
+++ b/src/project.v
@@ -12,20 +12,53 @@ module tt_um_simonsays (
     input  wire       rst_n     // reset_n - low to reset
 );
 
-  wire lfsr_comp;
-  
-    // Instantiate only the LFSR_OLD module and connect all I/O
-    LFSR lfsr_inst (
-        .LFSR_SEED(ui_in[7:0]),      // Use the first 7 bits of ui_in as the seed
+  // Local Signals
+    //Input
+    wire [3:0] colour_dec_in = ui_in[3:0];                // 4-bit input for colour decoding
+    wire reset = ui_in[4];                             // Reset signal
+    wire start = ui_in[5];                                // Start signal
+    wire [7:0] LFSR_SEED = uio_in[7:0];
+
+    //LFSR
+    wire [7:0] LFSR_out;
+    wire complete_LFSR;                                      // LFSR completion signal
+    wire en_LFSR;
+
+    //IDLE 
+    wire en_IDLE;
+    wire rst_IDLE;
+    wire complete_IDLE;
+
+    //32bMEM
+    wire MEM_LOAD;
+    wire [7:0]MEM_IN; // load 8 bits at a time
+    wire [1:0]MEM_LOAD_VAL;
+
+
+    LFSR lfsr(
+        .LFSR_SEED(LFSR_SEED),      // Use the first 7 bits of ui_in as the seed
         .clk(clk),
-        .rst(~rst_n),                // Active low reset
+        .rst(rst_n),                // Active low reset
         .enable(ena),                // Enable signal
-        .LFSR_OUT(uo_out[7:0]),     // Output the LFSR value to uio_out[6:0]
-        .complete_LFSR(lfsr_comp)   // Indicate completion in the last bit of uio_out
+        .LFSR_OUT(LFSR_out),     // Output the LFSR value to uio_out[6:0]
+        .complete_LFSR(complete_LFSR)   // Indicate completion in the last bit of uio_out
     );
 
-    // All output pins must be assigned. If not used, assign to 0.
-    assign uio_out  = {7'b0, lfsr_comp};
-    assign uio_oe  = 8'b1111_1111; // All uio_out pins are outputs
+    IDLE_STATE idle(
+        .clk(clk),
+        .en_IDLE(en_IDLE),
+        .rst_IDLE(rst_IDLE),
+        .complete_LFSR(complete_LFSR),
+        .LFSR_output(LFSR_out), // Use the first 7 bits of LFSR output
+        .en_LFSR(en_LFSR),
+        .MEM_IN(MEM_IN), // Load the LFSR output into memory
+        .MEM_LOAD(MEM_LOAD),
+        .complete_IDLE(complete_IDLE),
+        .MEM_LOAD_VAL(MEM_LOAD_VAL)
+    );
 
+
+    // All output pins must be assigned. If not used, assign to 0.
+    assign uo_out  = MEM_IN;
+    assign uio_oe  = 8'b1111_1111; // All uio_out pins are outputs
 endmodule

--- a/src/project.v
+++ b/src/project.v
@@ -25,9 +25,9 @@ module tt_um_simonsays (
     wire en_LFSR;
 
     //IDLE 
-    wire en_IDLE = ui_in[6]; // temp
-    wire rst_IDLE = ui_in[6]; // temp
-    wire complete_IDLE = ui_in[6]; // temp
+    wire en_IDLE; // temp
+    wire rst_IDLE; // temp
+    wire complete_IDLE; // temp
 
     //32bMEM
     wire MEM_LOAD;
@@ -58,8 +58,11 @@ module tt_um_simonsays (
     );
 
 
+    assign en_IDLE = start; // Enable IDLE state when start is pressed
+    assign rst_IDLE = reset; // Reset IDLE state when reset is pressed
+
     // All output pins must be assigned. If not used, assign to 0.
     assign uo_out  = MEM_IN;
     assign uio_oe  = 8'b1111_1111; // All uio_out pins are outputs
-    assign uio_out = 8'b0;
+    assign uio_out = {7'b0, complete_IDLE};
 endmodule


### PR DESCRIPTION
Waits for an enable signal (en_IDLE) to start operation.
On reset (rst_IDLE), clears all outputs and internal state.
Monitors complete_LFSR to detect when new LFSR data is ready.
Loads 8-bit LFSR output into a memory input register (MEM_IN) and asserts a memory load signal (MEM_LOAD).
Cycles through four memory locations using a 2-bit counter (MEM_LOAD_VAL), loading each with new LFSR data.
After all four locations are loaded, asserts a completion signal (complete_IDLE) and resets the counter.
Controls when the LFSR is enabled or disabled via en_LFSR.