### PR TITLE
32b reg mem

### DIFF
--- a/info.yaml
+++ b/info.yaml
@@ -20,6 +20,7 @@ project:
     - "project.v"
     - "LFSR.v"
     - "idle_state.v"
+    - "32b_Reg_Mem.v"
 
 # The pinout of your project. Leave unused pins blank. DO NOT delete or add any pins.
 # This section is for the datasheet/website. Use descriptive names (e.g., RX, TX, MOSI, SCL, SEG_A, etc.).

--- a/src/32b_Reg_Mem.v
+++ b/src/32b_Reg_Mem.v
@@ -18,42 +18,17 @@ module 32b_Reg_Mem(
     output wire [31:0] 32b_MEM_OUT
 );
 
-wire dff_en_0_7 = (32b_MEM_LOAD_VAL == 2'b00);
-wire dff_en_8_15 = (32b_MEM_LOAD_VAL == 2'b01);
-wire dff_en_16_23 = (32b_MEM_LOAD_VAL == 2'b10);
-wire dff_en_24_31 = (32b_MEM_LOAD_VAL == 2'b11);
+@always (posedge clk)begin
+    if(rst_32b_MEM)
+        32b_MEM_OUT  <= 32'b00000000000000000000000000000000;
+    else if(32b_MEM_LOAD_VAL == 2'b00 && 32b_MEM_LOAD)
+        32b_MEM_OUT <= {32b_MEM_OUT[31:8], 32b_MEM_IN[7:0]}
+    else if(32b_MEM_LOAD_VAL == 2'b01 && 32b_MEM_LOAD)
+        32b_MEM_OUT <= {32b_MEM_OUT[31:16], 32b_MEM_IN[7:0], 32b_MEM_OUT[7:0]}
+    else if(32b_MEM_LOAD_VAL == 2'b10 && 32b_MEM_LOAD)
+        32b_MEM_OUT <= {32b_MEM_OUT[31:24], 32b_MEM_IN[7:0], 32b_MEM_OUT[15:0]}
+    else if(32b_MEM_LOAD_VAL == 2'11 && 32b_MEM_LOAD)
+        32b_MEM_OUT <= {32b_MEM_IN[7:0], 32b_MEM_OUT[23:0]}
 
-dff dff_0(.q(32b_MEM_OUT[0]), .d(32b_MEM_IN[0]), .clk(clk), .en(dff_en_0_7), .rst(rst_32b_MEM));
-dff dff_1(.q(32b_MEM_OUT[1]), .d(32b_MEM_IN[1]), .clk(clk), .en(dff_en_0_7), .rst(rst_32b_MEM));
-dff dff_2(.q(32b_MEM_OUT[2]), .d(32b_MEM_IN[2]), .clk(clk), .en(dff_en_0_7), .rst(rst_32b_MEM));
-dff dff_3(.q(32b_MEM_OUT[3]), .d(32b_MEM_IN[3]), .clk(clk), .en(dff_en_0_7), .rst(rst_32b_MEM));
-dff dff_4(.q(32b_MEM_OUT[4]), .d(32b_MEM_IN[4]), .clk(clk), .en(dff_en_0_7), .rst(rst_32b_MEM));
-dff dff_5(.q(32b_MEM_OUT[5]), .d(32b_MEM_IN[5]), .clk(clk), .en(dff_en_0_7), .rst(rst_32b_MEM));
-dff dff_6(.q(32b_MEM_OUT[6]), .d(32b_MEM_IN[6]), .clk(clk), .en(dff_en_0_7), .rst(rst_32b_MEM));
-dff dff_7(.q(32b_MEM_OUT[7]), .d(32b_MEM_IN[7]), .clk(clk), .en(dff_en_0_7), .rst(rst_32b_MEM));
-dff dff_8(.q(32b_MEM_OUT[0]), .d(32b_MEM_IN[8]), .clk(clk), .en(dff_en_8_15), .rst(rst_32b_MEM));
-dff dff_9(.q(32b_MEM_OUT[1]), .d(32b_MEM_IN[9]), .clk(clk), .en(dff_en_8_15), .rst(rst_32b_MEM));
-dff dff_10(.q(32b_MEM_OUT[2]), .d(32b_MEM_IN[10]), .clk(clk), .en(dff_en_8_15), .rst(rst_32b_MEM));
-dff dff_11(.q(32b_MEM_OUT[3]), .d(32b_MEM_IN[11]), .clk(clk), .en(dff_en_8_15), .rst(rst_32b_MEM));
-dff dff_12(.q(32b_MEM_OUT[4]), .d(32b_MEM_IN[12]), .clk(clk), .en(dff_en_8_15), .rst(rst_32b_MEM));
-dff dff_13(.q(32b_MEM_OUT[5]), .d(32b_MEM_IN[13]), .clk(clk), .en(dff_en_8_15), .rst(rst_32b_MEM));
-dff dff_14(.q(32b_MEM_OUT[6]), .d(32b_MEM_IN[14]), .clk(clk), .en(dff_en_8_15), .rst(rst_32b_MEM));
-dff dff_15(.q(32b_MEM_OUT[7]), .d(32b_MEM_IN[15]), .clk(clk), .en(dff_en_8_15), .rst(rst_32b_MEM));
-dff dff_16(.q(32b_MEM_OUT[0]), .d(32b_MEM_IN[16]), .clk(clk), .en(dff_en_16_23), .rst(rst_32b_MEM));
-dff dff_17(.q(32b_MEM_OUT[1]), .d(32b_MEM_IN[17]), .clk(clk), .en(dff_en_16_23), .rst(rst_32b_MEM));
-dff dff_18(.q(32b_MEM_OUT[2]), .d(32b_MEM_IN[18]), .clk(clk), .en(dff_en_16_23), .rst(rst_32b_MEM));
-dff dff_19(.q(32b_MEM_OUT[3]), .d(32b_MEM_IN[19]), .clk(clk), .en(dff_en_16_23), .rst(rst_32b_MEM));
-dff dff_20(.q(32b_MEM_OUT[4]), .d(32b_MEM_IN[20]), .clk(clk), .en(dff_en_16_23), .rst(rst_32b_MEM));
-dff dff_21(.q(32b_MEM_OUT[5]), .d(32b_MEM_IN[21]), .clk(clk), .en(dff_en_16_23), .rst(rst_32b_MEM));
-dff dff_22(.q(32b_MEM_OUT[6]), .d(32b_MEM_IN[22]), .clk(clk), .en(dff_en_16_23), .rst(rst_32b_MEM));
-dff dff_23(.q(32b_MEM_OUT[7]), .d(32b_MEM_IN[23]), .clk(clk), .en(dff_en_16_23), .rst(rst_32b_MEM));
-dff dff_24(.q(32b_MEM_OUT[0]), .d(32b_MEM_IN[24]), .clk(clk), .en(dff_en_24_31), .rst(rst_32b_MEM));
-dff dff_25(.q(32b_MEM_OUT[1]), .d(32b_MEM_IN[25]), .clk(clk), .en(dff_en_24_31), .rst(rst_32b_MEM));
-dff dff_26(.q(32b_MEM_OUT[2]), .d(32b_MEM_IN[26]), .clk(clk), .en(dff_en_24_31), .rst(rst_32b_MEM));
-dff dff_27(.q(32b_MEM_OUT[3]), .d(32b_MEM_IN[27]), .clk(clk), .en(dff_en_24_31), .rst(rst_32b_MEM));
-dff dff_28(.q(32b_MEM_OUT[4]), .d(32b_MEM_IN[28]), .clk(clk), .en(dff_en_24_31), .rst(rst_32b_MEM));
-dff dff_29(.q(32b_MEM_OUT[5]), .d(32b_MEM_IN[29]), .clk(clk), .en(dff_en_24_31), .rst(rst_32b_MEM));
-dff dff_30(.q(32b_MEM_OUT[6]), .d(32b_MEM_IN[30]), .clk(clk), .en(dff_en_24_31), .rst(rst_32b_MEM));
-dff dff_31(.q(32b_MEM_OUT[7]), .d(32b_MEM_IN[31]), .clk(clk), .en(dff_en_24_31), .rst(rst_32b_MEM));
 
 endmodule

--- a/src/32b_Reg_Mem.v
+++ b/src/32b_Reg_Mem.v
@@ -12,42 +12,48 @@ endmodule
 module 32b_Reg_Mem(
     input wire clk,
     input wire 32b_MEM_LOAD,
-    input wire [31:0] 32b_MEM_IN,
+    input wire [7:0] 32b_MEM_IN,
     input wire rst_32b_MEM,
+    input wire [1:0] 32b_MEM_LOAD_VAL, // which bits to load.
     output wire [31:0] 32b_MEM_OUT
 );
 
-dff dff_0(.q(32b_MEM_OUT[0]), .d(32b_MEM_IN[0]), .clk(clk), .en(32b_MEM_LOAD), .rst(rst_32b_MEM));
-dff dff_1(.q(32b_MEM_OUT[1]), .d(32b_MEM_IN[1]), .clk(clk), .en(32b_MEM_LOAD), .rst(rst_32b_MEM));
-dff dff_2(.q(32b_MEM_OUT[2]), .d(32b_MEM_IN[2]), .clk(clk), .en(32b_MEM_LOAD), .rst(rst_32b_MEM));
-dff dff_3(.q(32b_MEM_OUT[3]), .d(32b_MEM_IN[3]), .clk(clk), .en(32b_MEM_LOAD), .rst(rst_32b_MEM));
-dff dff_4(.q(32b_MEM_OUT[4]), .d(32b_MEM_IN[4]), .clk(clk), .en(32b_MEM_LOAD), .rst(rst_32b_MEM));
-dff dff_5(.q(32b_MEM_OUT[5]), .d(32b_MEM_IN[5]), .clk(clk), .en(32b_MEM_LOAD), .rst(rst_32b_MEM));
-dff dff_6(.q(32b_MEM_OUT[6]), .d(32b_MEM_IN[6]), .clk(clk), .en(32b_MEM_LOAD), .rst(rst_32b_MEM));
-dff dff_7(.q(32b_MEM_OUT[7]), .d(32b_MEM_IN[7]), .clk(clk), .en(32b_MEM_LOAD), .rst(rst_32b_MEM));
-dff dff_8(.q(32b_MEM_OUT[8]), .d(32b_MEM_IN[8]), .clk(clk), .en(32b_MEM_LOAD), .rst(rst_32b_MEM));
-dff dff_9(.q(32b_MEM_OUT[9]), .d(32b_MEM_IN[9]), .clk(clk), .en(32b_MEM_LOAD), .rst(rst_32b_MEM));
-dff dff_10(.q(32b_MEM_OUT[10]), .d(32b_MEM_IN[10]), .clk(clk), .en(32b_MEM_LOAD), .rst(rst_32b_MEM));
-dff dff_11(.q(32b_MEM_OUT[11]), .d(32b_MEM_IN[11]), .clk(clk), .en(32b_MEM_LOAD), .rst(rst_32b_MEM));
-dff dff_12(.q(32b_MEM_OUT[12]), .d(32b_MEM_IN[12]), .clk(clk), .en(32b_MEM_LOAD), .rst(rst_32b_MEM));
-dff dff_13(.q(32b_MEM_OUT[13]), .d(32b_MEM_IN[13]), .clk(clk), .en(32b_MEM_LOAD), .rst(rst_32b_MEM));
-dff dff_14(.q(32b_MEM_OUT[14]), .d(32b_MEM_IN[14]), .clk(clk), .en(32b_MEM_LOAD), .rst(rst_32b_MEM));
-dff dff_15(.q(32b_MEM_OUT[15]), .d(32b_MEM_IN[15]), .clk(clk), .en(32b_MEM_LOAD), .rst(rst_32b_MEM));
-dff dff_16(.q(32b_MEM_OUT[16]), .d(32b_MEM_IN[16]), .clk(clk), .en(32b_MEM_LOAD), .rst(rst_32b_MEM));
-dff dff_17(.q(32b_MEM_OUT[17]), .d(32b_MEM_IN[17]), .clk(clk), .en(32b_MEM_LOAD), .rst(rst_32b_MEM));
-dff dff_18(.q(32b_MEM_OUT[18]), .d(32b_MEM_IN[18]), .clk(clk), .en(32b_MEM_LOAD), .rst(rst_32b_MEM));
-dff dff_19(.q(32b_MEM_OUT[19]), .d(32b_MEM_IN[19]), .clk(clk), .en(32b_MEM_LOAD), .rst(rst_32b_MEM));
-dff dff_20(.q(32b_MEM_OUT[20]), .d(32b_MEM_IN[20]), .clk(clk), .en(32b_MEM_LOAD), .rst(rst_32b_MEM));
-dff dff_21(.q(32b_MEM_OUT[21]), .d(32b_MEM_IN[21]), .clk(clk), .en(32b_MEM_LOAD), .rst(rst_32b_MEM));
-dff dff_22(.q(32b_MEM_OUT[22]), .d(32b_MEM_IN[22]), .clk(clk), .en(32b_MEM_LOAD), .rst(rst_32b_MEM));
-dff dff_23(.q(32b_MEM_OUT[23]), .d(32b_MEM_IN[23]), .clk(clk), .en(32b_MEM_LOAD), .rst(rst_32b_MEM));
-dff dff_24(.q(32b_MEM_OUT[24]), .d(32b_MEM_IN[24]), .clk(clk), .en(32b_MEM_LOAD), .rst(rst_32b_MEM));
-dff dff_25(.q(32b_MEM_OUT[25]), .d(32b_MEM_IN[25]), .clk(clk), .en(32b_MEM_LOAD), .rst(rst_32b_MEM));
-dff dff_26(.q(32b_MEM_OUT[26]), .d(32b_MEM_IN[26]), .clk(clk), .en(32b_MEM_LOAD), .rst(rst_32b_MEM));
-dff dff_27(.q(32b_MEM_OUT[27]), .d(32b_MEM_IN[27]), .clk(clk), .en(32b_MEM_LOAD), .rst(rst_32b_MEM));
-dff dff_28(.q(32b_MEM_OUT[28]), .d(32b_MEM_IN[28]), .clk(clk), .en(32b_MEM_LOAD), .rst(rst_32b_MEM));
-dff dff_29(.q(32b_MEM_OUT[29]), .d(32b_MEM_IN[29]), .clk(clk), .en(32b_MEM_LOAD), .rst(rst_32b_MEM));
-dff dff_30(.q(32b_MEM_OUT[30]), .d(32b_MEM_IN[30]), .clk(clk), .en(32b_MEM_LOAD), .rst(rst_32b_MEM));
-dff dff_31(.q(32b_MEM_OUT[31]), .d(32b_MEM_IN[31]), .clk(clk), .en(32b_MEM_LOAD), .rst(rst_32b_MEM));
+wire dff_en_0_7 = (32b_MEM_LOAD_VAL == 2'b00);
+wire dff_en_8_15 = (32b_MEM_LOAD_VAL == 2'b01);
+wire dff_en_16_23 = (32b_MEM_LOAD_VAL == 2'b10);
+wire dff_en_24_31 = (32b_MEM_LOAD_VAL == 2'b11);
+
+dff dff_0(.q(32b_MEM_OUT[0]), .d(32b_MEM_IN[0]), .clk(clk), .en(dff_en_0_7), .rst(rst_32b_MEM));
+dff dff_1(.q(32b_MEM_OUT[1]), .d(32b_MEM_IN[1]), .clk(clk), .en(dff_en_0_7), .rst(rst_32b_MEM));
+dff dff_2(.q(32b_MEM_OUT[2]), .d(32b_MEM_IN[2]), .clk(clk), .en(dff_en_0_7), .rst(rst_32b_MEM));
+dff dff_3(.q(32b_MEM_OUT[3]), .d(32b_MEM_IN[3]), .clk(clk), .en(dff_en_0_7), .rst(rst_32b_MEM));
+dff dff_4(.q(32b_MEM_OUT[4]), .d(32b_MEM_IN[4]), .clk(clk), .en(dff_en_0_7), .rst(rst_32b_MEM));
+dff dff_5(.q(32b_MEM_OUT[5]), .d(32b_MEM_IN[5]), .clk(clk), .en(dff_en_0_7), .rst(rst_32b_MEM));
+dff dff_6(.q(32b_MEM_OUT[6]), .d(32b_MEM_IN[6]), .clk(clk), .en(dff_en_0_7), .rst(rst_32b_MEM));
+dff dff_7(.q(32b_MEM_OUT[7]), .d(32b_MEM_IN[7]), .clk(clk), .en(dff_en_0_7), .rst(rst_32b_MEM));
+dff dff_8(.q(32b_MEM_OUT[0]), .d(32b_MEM_IN[8]), .clk(clk), .en(dff_en_8_15), .rst(rst_32b_MEM));
+dff dff_9(.q(32b_MEM_OUT[1]), .d(32b_MEM_IN[9]), .clk(clk), .en(dff_en_8_15), .rst(rst_32b_MEM));
+dff dff_10(.q(32b_MEM_OUT[2]), .d(32b_MEM_IN[10]), .clk(clk), .en(dff_en_8_15), .rst(rst_32b_MEM));
+dff dff_11(.q(32b_MEM_OUT[3]), .d(32b_MEM_IN[11]), .clk(clk), .en(dff_en_8_15), .rst(rst_32b_MEM));
+dff dff_12(.q(32b_MEM_OUT[4]), .d(32b_MEM_IN[12]), .clk(clk), .en(dff_en_8_15), .rst(rst_32b_MEM));
+dff dff_13(.q(32b_MEM_OUT[5]), .d(32b_MEM_IN[13]), .clk(clk), .en(dff_en_8_15), .rst(rst_32b_MEM));
+dff dff_14(.q(32b_MEM_OUT[6]), .d(32b_MEM_IN[14]), .clk(clk), .en(dff_en_8_15), .rst(rst_32b_MEM));
+dff dff_15(.q(32b_MEM_OUT[7]), .d(32b_MEM_IN[15]), .clk(clk), .en(dff_en_8_15), .rst(rst_32b_MEM));
+dff dff_16(.q(32b_MEM_OUT[0]), .d(32b_MEM_IN[16]), .clk(clk), .en(dff_en_16_23), .rst(rst_32b_MEM));
+dff dff_17(.q(32b_MEM_OUT[1]), .d(32b_MEM_IN[17]), .clk(clk), .en(dff_en_16_23), .rst(rst_32b_MEM));
+dff dff_18(.q(32b_MEM_OUT[2]), .d(32b_MEM_IN[18]), .clk(clk), .en(dff_en_16_23), .rst(rst_32b_MEM));
+dff dff_19(.q(32b_MEM_OUT[3]), .d(32b_MEM_IN[19]), .clk(clk), .en(dff_en_16_23), .rst(rst_32b_MEM));
+dff dff_20(.q(32b_MEM_OUT[4]), .d(32b_MEM_IN[20]), .clk(clk), .en(dff_en_16_23), .rst(rst_32b_MEM));
+dff dff_21(.q(32b_MEM_OUT[5]), .d(32b_MEM_IN[21]), .clk(clk), .en(dff_en_16_23), .rst(rst_32b_MEM));
+dff dff_22(.q(32b_MEM_OUT[6]), .d(32b_MEM_IN[22]), .clk(clk), .en(dff_en_16_23), .rst(rst_32b_MEM));
+dff dff_23(.q(32b_MEM_OUT[7]), .d(32b_MEM_IN[23]), .clk(clk), .en(dff_en_16_23), .rst(rst_32b_MEM));
+dff dff_24(.q(32b_MEM_OUT[0]), .d(32b_MEM_IN[24]), .clk(clk), .en(dff_en_24_31), .rst(rst_32b_MEM));
+dff dff_25(.q(32b_MEM_OUT[1]), .d(32b_MEM_IN[25]), .clk(clk), .en(dff_en_24_31), .rst(rst_32b_MEM));
+dff dff_26(.q(32b_MEM_OUT[2]), .d(32b_MEM_IN[26]), .clk(clk), .en(dff_en_24_31), .rst(rst_32b_MEM));
+dff dff_27(.q(32b_MEM_OUT[3]), .d(32b_MEM_IN[27]), .clk(clk), .en(dff_en_24_31), .rst(rst_32b_MEM));
+dff dff_28(.q(32b_MEM_OUT[4]), .d(32b_MEM_IN[28]), .clk(clk), .en(dff_en_24_31), .rst(rst_32b_MEM));
+dff dff_29(.q(32b_MEM_OUT[5]), .d(32b_MEM_IN[29]), .clk(clk), .en(dff_en_24_31), .rst(rst_32b_MEM));
+dff dff_30(.q(32b_MEM_OUT[6]), .d(32b_MEM_IN[30]), .clk(clk), .en(dff_en_24_31), .rst(rst_32b_MEM));
+dff dff_31(.q(32b_MEM_OUT[7]), .d(32b_MEM_IN[31]), .clk(clk), .en(dff_en_24_31), .rst(rst_32b_MEM));
 
 endmodule

--- a/src/32b_Reg_Mem.v
+++ b/src/32b_Reg_Mem.v
@@ -1,0 +1,53 @@
+// remove dff module when merge w/ lfsr code, already defined there.
+module dff(output reg q, input d, input clk, input en, input rst);
+    always @(posedge clk or posedge rst) begin
+        if (rst)
+            q <= 1'b0;
+        else if (en)
+            q <= d;
+    end
+endmodule
+
+// 32-bit Register Memory w/ async reset signal.
+module 32b_Reg_Mem(
+    input wire clk,
+    input wire 32b_MEM_LOAD,
+    input wire [31:0] 32b_MEM_IN,
+    input wire rst_32b_MEM,
+    output wire [31:0] 32b_MEM_OUT
+);
+
+dff dff_0(.q(32b_MEM_OUT[0]), .d(32b_MEM_IN[0]), .clk(clk), .en(32b_MEM_LOAD), .rst(rst_32b_MEM));
+dff dff_1(.q(32b_MEM_OUT[1]), .d(32b_MEM_IN[1]), .clk(clk), .en(32b_MEM_LOAD), .rst(rst_32b_MEM));
+dff dff_2(.q(32b_MEM_OUT[2]), .d(32b_MEM_IN[2]), .clk(clk), .en(32b_MEM_LOAD), .rst(rst_32b_MEM));
+dff dff_3(.q(32b_MEM_OUT[3]), .d(32b_MEM_IN[3]), .clk(clk), .en(32b_MEM_LOAD), .rst(rst_32b_MEM));
+dff dff_4(.q(32b_MEM_OUT[4]), .d(32b_MEM_IN[4]), .clk(clk), .en(32b_MEM_LOAD), .rst(rst_32b_MEM));
+dff dff_5(.q(32b_MEM_OUT[5]), .d(32b_MEM_IN[5]), .clk(clk), .en(32b_MEM_LOAD), .rst(rst_32b_MEM));
+dff dff_6(.q(32b_MEM_OUT[6]), .d(32b_MEM_IN[6]), .clk(clk), .en(32b_MEM_LOAD), .rst(rst_32b_MEM));
+dff dff_7(.q(32b_MEM_OUT[7]), .d(32b_MEM_IN[7]), .clk(clk), .en(32b_MEM_LOAD), .rst(rst_32b_MEM));
+dff dff_8(.q(32b_MEM_OUT[8]), .d(32b_MEM_IN[8]), .clk(clk), .en(32b_MEM_LOAD), .rst(rst_32b_MEM));
+dff dff_9(.q(32b_MEM_OUT[9]), .d(32b_MEM_IN[9]), .clk(clk), .en(32b_MEM_LOAD), .rst(rst_32b_MEM));
+dff dff_10(.q(32b_MEM_OUT[10]), .d(32b_MEM_IN[10]), .clk(clk), .en(32b_MEM_LOAD), .rst(rst_32b_MEM));
+dff dff_11(.q(32b_MEM_OUT[11]), .d(32b_MEM_IN[11]), .clk(clk), .en(32b_MEM_LOAD), .rst(rst_32b_MEM));
+dff dff_12(.q(32b_MEM_OUT[12]), .d(32b_MEM_IN[12]), .clk(clk), .en(32b_MEM_LOAD), .rst(rst_32b_MEM));
+dff dff_13(.q(32b_MEM_OUT[13]), .d(32b_MEM_IN[13]), .clk(clk), .en(32b_MEM_LOAD), .rst(rst_32b_MEM));
+dff dff_14(.q(32b_MEM_OUT[14]), .d(32b_MEM_IN[14]), .clk(clk), .en(32b_MEM_LOAD), .rst(rst_32b_MEM));
+dff dff_15(.q(32b_MEM_OUT[15]), .d(32b_MEM_IN[15]), .clk(clk), .en(32b_MEM_LOAD), .rst(rst_32b_MEM));
+dff dff_16(.q(32b_MEM_OUT[16]), .d(32b_MEM_IN[16]), .clk(clk), .en(32b_MEM_LOAD), .rst(rst_32b_MEM));
+dff dff_17(.q(32b_MEM_OUT[17]), .d(32b_MEM_IN[17]), .clk(clk), .en(32b_MEM_LOAD), .rst(rst_32b_MEM));
+dff dff_18(.q(32b_MEM_OUT[18]), .d(32b_MEM_IN[18]), .clk(clk), .en(32b_MEM_LOAD), .rst(rst_32b_MEM));
+dff dff_19(.q(32b_MEM_OUT[19]), .d(32b_MEM_IN[19]), .clk(clk), .en(32b_MEM_LOAD), .rst(rst_32b_MEM));
+dff dff_20(.q(32b_MEM_OUT[20]), .d(32b_MEM_IN[20]), .clk(clk), .en(32b_MEM_LOAD), .rst(rst_32b_MEM));
+dff dff_21(.q(32b_MEM_OUT[21]), .d(32b_MEM_IN[21]), .clk(clk), .en(32b_MEM_LOAD), .rst(rst_32b_MEM));
+dff dff_22(.q(32b_MEM_OUT[22]), .d(32b_MEM_IN[22]), .clk(clk), .en(32b_MEM_LOAD), .rst(rst_32b_MEM));
+dff dff_23(.q(32b_MEM_OUT[23]), .d(32b_MEM_IN[23]), .clk(clk), .en(32b_MEM_LOAD), .rst(rst_32b_MEM));
+dff dff_24(.q(32b_MEM_OUT[24]), .d(32b_MEM_IN[24]), .clk(clk), .en(32b_MEM_LOAD), .rst(rst_32b_MEM));
+dff dff_25(.q(32b_MEM_OUT[25]), .d(32b_MEM_IN[25]), .clk(clk), .en(32b_MEM_LOAD), .rst(rst_32b_MEM));
+dff dff_26(.q(32b_MEM_OUT[26]), .d(32b_MEM_IN[26]), .clk(clk), .en(32b_MEM_LOAD), .rst(rst_32b_MEM));
+dff dff_27(.q(32b_MEM_OUT[27]), .d(32b_MEM_IN[27]), .clk(clk), .en(32b_MEM_LOAD), .rst(rst_32b_MEM));
+dff dff_28(.q(32b_MEM_OUT[28]), .d(32b_MEM_IN[28]), .clk(clk), .en(32b_MEM_LOAD), .rst(rst_32b_MEM));
+dff dff_29(.q(32b_MEM_OUT[29]), .d(32b_MEM_IN[29]), .clk(clk), .en(32b_MEM_LOAD), .rst(rst_32b_MEM));
+dff dff_30(.q(32b_MEM_OUT[30]), .d(32b_MEM_IN[30]), .clk(clk), .en(32b_MEM_LOAD), .rst(rst_32b_MEM));
+dff dff_31(.q(32b_MEM_OUT[31]), .d(32b_MEM_IN[31]), .clk(clk), .en(32b_MEM_LOAD), .rst(rst_32b_MEM));
+
+endmodule

--- a/src/32b_Reg_Mem.v
+++ b/src/32b_Reg_Mem.v
@@ -1,34 +1,24 @@
-// remove dff module when merge w/ lfsr code, already defined there.
-module dff(output reg q, input d, input clk, input en, input rst);
-    always @(posedge clk or posedge rst) begin
-        if (rst)
-            q <= 1'b0;
-        else if (en)
-            q <= d;
-    end
-endmodule
-
 // 32-bit Register Memory w/ async reset signal.
-module 32b_Reg_Mem(
+module MEM(
     input wire clk,
-    input wire 32b_MEM_LOAD,
-    input wire [7:0] 32b_MEM_IN,
-    input wire rst_32b_MEM,
-    input wire [1:0] 32b_MEM_LOAD_VAL, // which bits to load.
-    output wire [31:0] 32b_MEM_OUT
+    input wire MEM_LOAD,
+    input wire [7:0] MEM_IN,
+    input wire rst_MEM,
+    input wire [1:0] MEM_LOAD_VAL, // which bits to load.
+    output reg[31:0] MEM_OUT
 );
 
-@always (posedge clk)begin
-    if(rst_32b_MEM)
-        32b_MEM_OUT  <= 32'b00000000000000000000000000000000;
-    else if(32b_MEM_LOAD_VAL == 2'b00 && 32b_MEM_LOAD)
-        32b_MEM_OUT <= {32b_MEM_OUT[31:8], 32b_MEM_IN[7:0]}
-    else if(32b_MEM_LOAD_VAL == 2'b01 && 32b_MEM_LOAD)
-        32b_MEM_OUT <= {32b_MEM_OUT[31:16], 32b_MEM_IN[7:0], 32b_MEM_OUT[7:0]}
-    else if(32b_MEM_LOAD_VAL == 2'b10 && 32b_MEM_LOAD)
-        32b_MEM_OUT <= {32b_MEM_OUT[31:24], 32b_MEM_IN[7:0], 32b_MEM_OUT[15:0]}
-    else if(32b_MEM_LOAD_VAL == 2'11 && 32b_MEM_LOAD)
-        32b_MEM_OUT <= {32b_MEM_IN[7:0], 32b_MEM_OUT[23:0]}
-
-
+always @(posedge clk)begin
+    if(rst_MEM)begin
+        MEM_OUT  <= 32'b00000000000000000000000000000000;
+    end else if(MEM_LOAD_VAL == 2'b00 && MEM_LOAD) begin
+        MEM_OUT <= {MEM_OUT[31:8], MEM_IN[7:0]};
+    end else if(MEM_LOAD_VAL == 2'b01 && MEM_LOAD) begin
+        MEM_OUT <= {MEM_OUT[31:16], MEM_IN[7:0], MEM_OUT[7:0]};
+    end else if(MEM_LOAD_VAL == 2'b10 && MEM_LOAD) begin
+        MEM_OUT <= {MEM_OUT[31:24], MEM_IN[7:0], MEM_OUT[15:0]};
+    end else if(MEM_LOAD_VAL == 2'b11 && MEM_LOAD)begin
+        MEM_OUT <= {MEM_IN[7:0], MEM_OUT[23:0]};
+    end 
+    end
 endmodule

--- a/src/32b_Reg_Mem_tb.v
+++ b/src/32b_Reg_Mem_tb.v
@@ -1,0 +1,83 @@
+`timescale 1ns/1ps
+
+module tb_32b_Reg_Mem;
+
+    reg clk = 0;
+    reg rst_MEM = 0;
+    reg MEM_LOAD = 0;
+    reg [7:0] MEM_IN = 8'h00;
+    reg [1:0] MEM_LOAD_VAL = 2'b00;
+    wire [31:0] MEM_OUT;
+
+    // Instantiate the DUT
+    MEM dut (
+        .clk(clk),
+        .MEM_LOAD(MEM_LOAD),
+        .MEM_IN(MEM_IN),
+        .rst_MEM(rst_MEM),
+        .MEM_LOAD_VAL(MEM_LOAD_VAL),
+        .MEM_OUT(MEM_OUT)
+    );
+
+    // Clock generation
+    always #5 clk = ~clk;
+
+    initial begin
+        $dumpfile("tb_32b_Reg_Mem.vcd");
+        $dumpvars(0, tb_32b_Reg_Mem);
+
+        // Reset the memory
+        rst_MEM = 1;
+        MEM_LOAD = 0;
+        MEM_IN = 8'h00;
+        MEM_LOAD_VAL = 2'b00;
+        @(negedge clk);
+        rst_MEM = 0;
+
+        // Load 0xAA into byte 0
+        MEM_LOAD = 1;
+        MEM_IN = 8'hAA;
+        MEM_LOAD_VAL = 2'b00;
+        @(negedge clk);
+        MEM_LOAD = 0;
+        @(negedge clk);
+
+        // Load 0xBB into byte 1
+        MEM_LOAD = 1;
+        MEM_IN = 8'hFF;
+        MEM_LOAD_VAL = 2'b01;
+        @(negedge clk);
+        MEM_LOAD = 0;
+        @(negedge clk);
+
+        // Load 0xCC into byte 2
+        MEM_LOAD = 1;
+        MEM_IN = 8'hCC;
+        MEM_LOAD_VAL = 2'b10;
+        @(negedge clk);
+        MEM_LOAD = 0;
+        @(negedge clk);
+
+        // Load 0xDD into byte 3
+        MEM_LOAD = 1;
+        MEM_IN = 8'hDD;
+        MEM_LOAD_VAL = 2'b11;
+        @(negedge clk);
+        MEM_LOAD = 0;
+        @(negedge clk);
+
+        // Display the final memory value
+        $display("Final MEM_OUT = %h", MEM_OUT);
+
+        #20;
+        $finish;
+    end
+
+    // Monitor only the requested signals
+    initial begin
+        $display("Time\trst_MEM\tMEM_LOAD\tMEM_IN\tMEM_LOAD_VAL");
+        $monitor("%0t\t%b\t%b\t%h\t%b",
+            $time, rst_MEM, MEM_LOAD, MEM_IN, MEM_LOAD_VAL);
+    end
+
+endmodule

--- a/src/project.v
+++ b/src/project.v
@@ -33,6 +33,8 @@ module tt_um_simonsays (
     wire MEM_LOAD;
     wire [7:0]MEM_IN; // load 8 bits at a time
     wire [1:0]MEM_LOAD_VAL;
+    wire rst_MEM;
+    wire [31:0]MEM_OUT;
 
 
     LFSR lfsr(
@@ -57,12 +59,26 @@ module tt_um_simonsays (
         .MEM_LOAD_VAL(MEM_LOAD_VAL)
     );
 
+    MEM mem(
+        .clk(clk),
+        .MEM_LOAD(MEM_LOAD),
+        .MEM_IN(MEM_IN),
+        .rst_MEM(rst_MEM),
+        .MEM_LOAD_VAL(MEM_LOAD_VAL),
+        .MEM_OUT(MEM_OUT)
+    );
 
     assign en_IDLE = start; // Enable IDLE state when start is pressed
     assign rst_IDLE = reset; // Reset IDLE state when reset is pressed
+    assign rst_MEM = reset;
+
+    //temp to make sure mem out signals are used
+    wire mem_out_xor;
+    assign mem_out_xor = ^MEM_OUT; // Reduction XOR operator
+
 
     // All output pins must be assigned. If not used, assign to 0.
     assign uo_out  = MEM_IN;
     assign uio_oe  = 8'b1111_1111; // All uio_out pins are outputs
-    assign uio_out = {7'b0, complete_IDLE};
+    assign uio_out = {6'b0, mem_out_xor, complete_IDLE};
 endmodule


### PR DESCRIPTION
Implements a 32-bit register with asynchronous reset.
Allows loading 8 bits at a time into any of the four bytes of the 32-bit register, based on a 2-bit selector (MEM_LOAD_VAL).
On reset (rst_MEM), clears the entire 32-bit register to zero.
When MEM_LOAD is asserted, updates the selected byte with MEM_IN while preserving the other bytes.
Outputs the current 32-bit register value on MEM_OUT.